### PR TITLE
Show export JSON modal

### DIFF
--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -8,6 +8,7 @@ export const Overlay: React.FC = () => {
     if (!snap.model) return null
 
     const [openOverlay, setOpenOverlay] = React.useState(false)
+    const [exportJson, setExportJson] = React.useState<string | null>(null)
 
     const screenShot = () => {
         const canvas = document.querySelector('canvas')
@@ -45,13 +46,7 @@ export const Overlay: React.FC = () => {
             camera_zoom: snap.cameraZoom,
         }
         const json = JSON.stringify(data, null, 2)
-        const blob = new Blob([json], {type: 'application/json'})
-        const url = URL.createObjectURL(blob)
-        const link = document.createElement('a')
-        link.href = url
-        link.download = snap.model.name + '-scene-settings.json'
-        link.click()
-        URL.revokeObjectURL(url)
+        setExportJson(json)
     }
 
     const stopEvent = (e: React.SyntheticEvent) => {
@@ -64,6 +59,14 @@ export const Overlay: React.FC = () => {
             <button className={'open-overlay'} onClick={() => setOpenOverlay(!openOverlay)}>
                 {openOverlay ? 'Close' : 'Open'} overlay
             </button>
+            {exportJson && (
+                <div className="export-modal" onClick={() => setExportJson(null)}>
+                    <div className="export-modal-content" onClick={stopEvent}>
+                        <pre>{exportJson}</pre>
+                        <button onClick={() => navigator.clipboard.writeText(exportJson)}>COPY</button>
+                    </div>
+                </div>
+            )}
             <div className={`customizer`} style={{display: openOverlay ? 'flex' : ''}}
                  onWheelCapture={stopEvent}
                  onPointerDownCapture={stopEvent}

--- a/src/styles.css
+++ b/src/styles.css
@@ -351,3 +351,33 @@ button:hover {
     display: flex;
     flex-direction: column;
 }
+
+.export-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+}
+
+.export-modal-content {
+    background: white;
+    padding: 20px;
+    max-width: 600px;
+    max-height: 80%;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.export-modal pre {
+    background: #f0f0f0;
+    padding: 10px;
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow: auto;
+}


### PR DESCRIPTION
## Summary
- open export JSON in a modal instead of downloading
- add styles for the export modal

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_68496733e2a4832481d419fd09e3081b